### PR TITLE
Added repo for Ubuntu Focal on arm64

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -124,6 +124,11 @@ class zabbix::repo (
         } else {
           if ($facts['os']['distro'][id] == 'Raspbian') {
             $operatingsystem = 'raspbian'
+          } elsif ($facts['os']['architecture'] == 'aarch64' and $facts['os']['distro']['codename'] == 'focal')  {
+            $operatingsystem = 'ubuntu-arm64'
+            if versioncmp($zabbix_version, '5.0') < 0 {
+              fail("Only packages for zabbix version 5.0 and newer are available for arm64!")
+            }
           } else {
             $operatingsystem = downcase($facts['os']['name'])
           }


### PR DESCRIPTION
Zabbix now provides Ubuntu Focal deb packages for the arm64 architecture:
https://support.zabbix.com/browse/ZBXNEXT-5982

They can be found under a different URL than "usual":
https://repo.zabbix.com/zabbix/5.2/ubuntu-arm64/

so the repo.pp manifest has to be adapted to refelct this.

Be careful: Right now, Zabbix only provides packages for version 5.0 and 5.2.